### PR TITLE
Small fixes for modern Futhark and better example

### DIFF
--- a/examples/play_file.nims
+++ b/examples/play_file.nims
@@ -1,1 +1,3 @@
+--passL:"-lvlc"
+--maxLoopIterationsVM:1000000000
 switch("path", "../src/")

--- a/src/libvlc.nim
+++ b/src/libvlc.nim
@@ -2,7 +2,7 @@ import std/strutils
 
 import futhark
 
-proc myRename(name, kind: string, partof = ""): string = 
+proc myRename(name, kind: string, partof = ""): string =
   result = name
   # Special-case libvlc_new
   if result == "libvlc_new":
@@ -12,7 +12,6 @@ proc myRename(name, kind: string, partof = ""): string =
 
 when defined(linux):
   importc:
-    sysPath "/usr/lib/clang/13.0.1/include"
-    path "/usr/include/"
+    path "/usr/include/vlc"
     renameCallback myRename
-    "vlc/vlc.h"
+    "vlc.h"


### PR DESCRIPTION
This just fixed the importc specification to work with modern Futhark. Also added some small things to the example config so that `nim c play_file` should work out of the box.

It could also be worth looking at https://github.com/PMunch/futhark?tab=readme-ov-file#shipping-wrappers, but the current wrapper built so fast it wasn't really anything I felt like addressing.

Oh, and why is this Linux only after the Futharkification?